### PR TITLE
feat!: add runtime type validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 /**
  * Remove leading slashes from a given string
- * @param  {String} str
+ * @param  {String} input
  * @return {String}
  */
-export default function removeLeadingSlash(str) {
-  return str.replace(/^\/+/, '');
+export default function removeLeadingSlash(input) {
+  if (typeof input !== 'string') {
+    throw new TypeError('Expected a string');
+  }
+  return input.replace(/^\/+/, '');
 }

--- a/test.js
+++ b/test.js
@@ -33,3 +33,16 @@ test('string without slashes', () => {
 
   assert.strictEqual(result, expected);
 });
+
+test('throws on non-string types', () => {
+  const expectedError = {
+    name: 'TypeError',
+    message: 'Expected a string'
+  };
+
+  assert.throws(() => removeLeadingSlash(null), expectedError);
+  assert.throws(() => removeLeadingSlash(undefined), expectedError);
+  assert.throws(() => removeLeadingSlash(123), expectedError);
+  assert.throws(() => removeLeadingSlash({}), expectedError);
+  assert.throws(() => removeLeadingSlash([]), expectedError);
+});


### PR DESCRIPTION
## What changed (additional context)

**BREAKING CHANGE**: 

Throw a TypeError when input is not a string. Pass `String(value)` before calling if coercion is desired.